### PR TITLE
Add retrofit-php codes with automatic signer

### DIFF
--- a/developers-sdk-php/README.md
+++ b/developers-sdk-php/README.md
@@ -1,13 +1,23 @@
-# LINE Blockchain Developers SDK for JavaScript
+# LINE Blockchain Developers SDK for PHP
 This is a subproject of LINE Blockchain Developers SDK. 
 See [README](../README.md) for overview.
 
-## Dependencies (Retrofit-php)
+## Install PHP composer
+```
+(From https://getcomposer.org/download/)
+
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+php -r "if (hash_file('sha384', 'composer-setup.php') === '756890a4488ce9024fc62c56153228907f1545c228516cbf63f885e036d37e9a59d27d63f46af1d4d07ee0f76181c7d3') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+php composer-setup.php
+php -r "unlink('composer-setup.php');"
+```
+
+## Install Dependencies (Retrofit-php)
 Please be sure PHP composer is installed
 
 ```
 cd sdk
-composer.phar install
+../composer.phar install
 ```
 
 ## Run all tests

--- a/developers-sdk-php/README.md
+++ b/developers-sdk-php/README.md
@@ -1,0 +1,22 @@
+# LINE Blockchain Developers SDK for JavaScript
+This is a subproject of LINE Blockchain Developers SDK. 
+See [README](../README.md) for overview.
+
+## Dependencies (Retrofit-php)
+Please be sure PHP composer is installed
+
+```
+cd sdk
+composer.phar install
+```
+
+## Run all tests
+Run the following command to test the library.
+
+```
+cd test
+php test_api_client.php
+php test.php
+```
+
+

--- a/developers-sdk-php/sdk/api_client.php
+++ b/developers-sdk-php/sdk/api_client.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Ryukato;
+
+require_once 'vendor/autoload.php';
+require_once 'autosigner.php';
+require_once 'array_converter_factory.php';
+
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Handler\CurlHandler;
+use Psr\Http\Message\RequestInterface;
+use GuzzleHttp\Middleware;
+
+use Tebru\Retrofit\Retrofit;
+use Tebru\Retrofit\RetrofitBuilder;
+use Tebru\RetrofitHttp\Guzzle6\Guzzle6HttpClient;
+use Tebru\Retrofit\Call;
+
+use Tebru\Retrofit\Annotation\GET;
+use Tebru\Retrofit\Annotation\POST;
+use Tebru\Retrofit\Annotation\PUT;
+use Tebru\Retrofit\Annotation\DELETE;
+use Tebru\Retrofit\Annotation\Path;
+use Tebru\Retrofit\Annotation\Query;
+use Tebru\Retrofit\Annotation\Body;
+
+use AuthorizedClient;
+use ArrayConverterFactory;
+
+interface ApiClient {
+    /**
+     * @GET("/v1/time")
+     */
+    public function time(): Call;
+
+    /**
+     * @GET("/v1/services/{service_id}")
+     * @Path("service_id")
+     */
+    public function service_detail(string $service_id): Call;
+
+    /**
+     * @GET("/v1/service-tokens/{contract_id}/holders")
+     * @Path("contract_id")
+     * @Query("limit")
+     * @Query("page")
+     * @Query("order_by")
+     */
+    public function service_token_holders(string $contract_id, int $limit, int $page, string $order_by): Call;
+
+    /**
+     * @PUT("/v1/service-tokens/{contract_id}")
+     * @Path("contract_id")
+     * @Body("update_request")
+     */
+    public function update_service_token_detail(string $contract_id, array $update_request): Call;
+
+    /**
+     * @POST("/v1/service-tokens/{contract_id}/mint")
+     * @Path("contract_id")
+     * @Body("service_token_mint_request")
+     */
+    public function mint_service_token(string $contract_id, array $service_token_mint_request): Call;
+
+    /**
+     * @PUT("/v1/item-tokens/{contract_id}/non-fungibles/{token_type}/{token_index}")
+     * @Path("contract_id")
+     * @Path("token_type")
+     * @Path("token_index")
+     * @Body("update_request")
+     */
+    public function update_non_fungible_token(string $contract_id, string $token_type, string $token_index, array $update_request): Call;
+}
+?>
+

--- a/developers-sdk-php/sdk/api_client.php
+++ b/developers-sdk-php/sdk/api_client.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Ryukato;
+namespace LineDevelopersSdk;
 
 require_once 'vendor/autoload.php';
 require_once 'autosigner.php';

--- a/developers-sdk-php/sdk/array_converter_factory.php
+++ b/developers-sdk-php/sdk/array_converter_factory.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Ryukato;
+namespace LineDevelopersSdk;
 
 require_once 'vendor/autoload.php';
 

--- a/developers-sdk-php/sdk/array_converter_factory.php
+++ b/developers-sdk-php/sdk/array_converter_factory.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Ryukato;
+
+require_once 'vendor/autoload.php';
+
+use GuzzleHttp\Psr7;
+use Psr\Http\Message\StreamInterface;
+use Tebru\PhpType\TypeToken;
+use Tebru\Retrofit\RequestBodyConverter;
+use Tebru\Retrofit\ResponseBodyConverter;
+use Tebru\Retrofit\ConverterFactory;
+use Tebru\Retrofit\StringConverter;
+
+class ArrayConverterFactory implements ConverterFactory {
+    public function __construct() {
+    }
+
+    public function responseBodyConverter(TypeToken $type): ?ResponseBodyConverter
+    {
+        return new ArrayResponseBodyConverter($type);
+    }
+
+    public function requestBodyConverter(TypeToken $type): ?RequestBodyConverter
+    {
+        return new ArrayRequestBodyConverter($type);
+    }
+
+    public function stringConverter(TypeToken $type): ?StringConverter
+    {
+        return null;
+    }
+}
+
+class ArrayResponseBodyConverter implements ResponseBodyConverter {
+    private $type;
+
+    public function __construct(TypeToken $type)
+    {
+        $this->type = $type;
+    }
+
+    public function convert($value): StreamInterface
+    {
+        if ($this->type->isA(StreamInterface::class)) {
+            return $value;
+        }
+
+        /** @noinspection ExceptionsAnnotatingAndHandlingInspection */
+        return Psr7\stream_for(json_encode($value));
+    }
+}
+
+class ArrayRequestBodyConverter implements RequestBodyConverter {
+    private $type;
+
+    public function __construct(TypeToken $type)
+    {
+        $this->type = $type;
+    }
+
+    public function convert($value): StreamInterface
+    {
+        if ($this->type->isA(StreamInterface::class)) {
+            return $value;
+        }
+
+        /** @noinspection ExceptionsAnnotatingAndHandlingInspection */
+        return Psr7\stream_for(json_encode($value));
+    }
+}
+
+?>

--- a/developers-sdk-php/sdk/autosigner.php
+++ b/developers-sdk-php/sdk/autosigner.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Ryukato;
+
+require_once 'vendor/autoload.php';
+require_once 'signature_generator.php';
+
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Handler\CurlHandler;
+use Psr\Http\Message\RequestInterface;
+use GuzzleHttp\Middleware;
+
+use Tebru\Retrofit\Retrofit;
+use Tebru\Retrofit\RetrofitBuilder;
+use Tebru\RetrofitHttp\Guzzle6\Guzzle6HttpClient;
+use Tebru\Retrofit\Call;
+
+use SignatureGenerator;
+use ReflectionObject;
+
+
+function get_timestamp()
+{
+    list($usec, $sec) = explode(" ", microtime());
+    return floor( ((float)$usec + (float)$sec) * 1000 );
+}
+
+class AuthorizedClientBuilder {
+    public static function build(string $api_secret) {
+        $handler = new CurlHandler();
+        $stack = HandlerStack::create($handler); // Wrap w/ middleware
+        $client = new Client(['handler' => $stack]);
+
+        $stack->push(Middleware::mapRequest(function (RequestInterface $r) {
+            $timestamp = get_timestamp();
+
+            $nonce_v = array();
+            $charset = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+            for ($x = 0; $x < 8; $x ++) {
+                array_push($nonce_v, $charset[rand() % strlen($charset)]);
+            }
+
+            $nonce = implode('', $nonce_v);
+
+            //
+            //  Use some reflection to access private fields
+            //
+            $reflect = new ReflectionObject($r);
+            $v = $reflect->getProperty('method');
+            $v->setAccessible(true);
+
+            $http_method = $v->getValue($r);
+
+            $v = $reflect->getProperty('uri');
+            $v->setAccessible(true);
+
+            $uri = $v->getValue($r);
+            
+            $http_path = str_replace("//", "/", $uri->getPath());
+
+            parse_str($uri->getQuery(), $query);
+
+            $s = new SignatureGenerator();
+            $signature = $s->generate($api_secret, $http_method, $http_path, 
+                                      $timestamp, $nonce, $query, array());
+
+            return $r->withHeader('Signature', $signature)
+                     ->withHeader('Nonce', $nonce)
+                     ->withHeader('Timestamp', $timestamp);
+        }, 'autosigner'));
+
+        return $client;
+    }
+}
+

--- a/developers-sdk-php/sdk/autosigner.php
+++ b/developers-sdk-php/sdk/autosigner.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Ryukato;
+namespace LineDevelopersSdk;
 
 require_once 'vendor/autoload.php';
 require_once 'signature_generator.php';
@@ -68,7 +68,8 @@ class AuthorizedClientBuilder {
 
             return $r->withHeader('Signature', $signature)
                      ->withHeader('Nonce', $nonce)
-                     ->withHeader('Timestamp', $timestamp);
+                     ->withHeader('Timestamp', $timestamp)
+                     ->withHeader('User-Agent', "LineDevelopersPhpSdk");
         }, 'autosigner'));
 
         return $client;

--- a/developers-sdk-php/sdk/composer.json
+++ b/developers-sdk-php/sdk/composer.json
@@ -1,0 +1,7 @@
+{
+    "require": {
+        "tebru/retrofit-php": "^3.3",
+        "tebru/retrofit-php-http-guzzle6": "^0.1.1",
+        "tebru/retrofit-php-converter-gson": "^0.3.0"
+    }
+}

--- a/developers-sdk-php/test/test_api_client.php
+++ b/developers-sdk-php/test/test_api_client.php
@@ -5,11 +5,11 @@ require_once '../sdk/api_client.php';
 use Tebru\Retrofit\Retrofit;
 use Tebru\RetrofitHttp\Guzzle6\Guzzle6HttpClient;
 
-use Ryukato\ApiClient;
-use Ryukato\AuthorizedClientBuilder;
-use Ryukato\ArrayConverterFactory;
+use LineDevelopersSdk\ApiClient;
+use LineDevelopersSdk\AuthorizedClientBuilder;
+use LineDevelopersSdk\ArrayConverterFactory;
 
-$api_secret = "9256bf8a-2b86-42fe-b3e0-d3079d0141fe";
+$api_secret = getenv("API_SECRET", true) ? :"9256bf8a-2b86-42fe-b3e0-d3079d0141fe";
 
 $retrofit = Retrofit::builder()
     ->setBaseUrl('http://localhost:9999')
@@ -17,7 +17,7 @@ $retrofit = Retrofit::builder()
     ->addConverterFactory(new ArrayConverterFactory())
     ->build();
 
-$service = $retrofit->create(Ryukato\ApiClient::class);
+$service = $retrofit->create(LineDevelopersSdk\ApiClient::class);
 
 $body = [
             "ownerAddress" => "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",

--- a/developers-sdk-php/test/test_api_client.php
+++ b/developers-sdk-php/test/test_api_client.php
@@ -1,0 +1,51 @@
+<?php
+
+require_once '../sdk/api_client.php';
+
+use Tebru\Retrofit\Retrofit;
+use Tebru\RetrofitHttp\Guzzle6\Guzzle6HttpClient;
+
+use Ryukato\ApiClient;
+use Ryukato\AuthorizedClientBuilder;
+use Ryukato\ArrayConverterFactory;
+
+$api_secret = "9256bf8a-2b86-42fe-b3e0-d3079d0141fe";
+
+$retrofit = Retrofit::builder()
+    ->setBaseUrl('http://localhost:9999')
+    ->setHttpClient(new Guzzle6HttpClient(AuthorizedClientBuilder::build($api_secret)))
+    ->addConverterFactory(new ArrayConverterFactory())
+    ->build();
+
+$service = $retrofit->create(Ryukato\ApiClient::class);
+
+$body = [
+            "ownerAddress" => "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+            "ownerSecret" => "uhbdnNvIqQFnnIFDDG8EuVxtqkwsLtDR/owKInQIYmo=",
+            "name" => "NewName"
+        ];
+
+$call = $service->update_non_fungible_token('61e14383', '10000001', '00000001', $body);
+var_dump($call);
+
+if (false) { // enable this to test actual http request sending 
+    $response = $call->execute();
+
+    /*
+        Example HTTP Request
+
+        PUT /v1/item-tokens/61e14383/non-fungibles/10000001/00000001 HTTP/1.1
+        Host: localhost:9999
+        User-Agent: GuzzleHttp/6.5.5 curl/7.64.1 PHP/7.3.24-(to be removed in future macOS)
+        content-type: application/json
+        Signature: Itb0ySMnx12/2ZUXGQdKJJo7b+hmOtr2I/o0ZuN1kQ5d9JZjpNuNMh4T7t3+UBdgNGAyzTZvVhXJuZ9e/V060w==
+        Nonce: BB3NYdAV
+        Timestamp: 1612717561481
+        Content-Length: 142
+
+        {"ownerAddress":"tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq","ownerSecret":"uhbdnNvIqQFnnIFDDG8EuVxtqkwsLtDR\/owKInQIYmo=","name":"NewName"}
+    */
+}
+
+
+?>


### PR DESCRIPTION
Using Retrofit-php, I implemented the following basic frame codes. ( Resolves #18 )

- GET/POST/PUT with query param/body param
- Automatic API Signing
- Array encoder for arbitrary json body input (I'm not sure it's a good way or not, maybe building models for each api could be better?)