### PR TITLE
Fix: `TextContent` wrapper has been used to calculate signature, instead of body text in developers-sdk-kt

### DIFF
--- a/developers-sdk-kt/src/main/kotlin/com/github/ryukato/link/developers/sdk/http/ApiClientRequestFeature.kt
+++ b/developers-sdk-kt/src/main/kotlin/com/github/ryukato/link/developers/sdk/http/ApiClientRequestFeature.kt
@@ -1,8 +1,11 @@
 package com.github.ryukato.link.developers.sdk.http
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.ktor.client.*
 import io.ktor.client.features.*
 import io.ktor.client.request.*
+import io.ktor.http.content.*
 import io.ktor.util.*
 import org.apache.commons.lang3.RandomStringUtils
 
@@ -57,11 +60,11 @@ internal class ApiClientRequestFeature(val config: Config) {
             }
         }
 
-        @Suppress("UNCHECKED_CAST")
         private fun bodyAsMap(context: HttpRequestBuilder): Map<String, Any> {
-            return when (context.body) {
-                is Map<*, *> -> context.body as Map<String, Any>
-                else -> emptyMap()
+            return if (context.body is TextContent) {
+                jacksonObjectMapper().readValue((context.body as TextContent).text)
+            } else {
+                emptyMap()
             }
         }
     }

--- a/developers-sdk-kt/src/main/kotlin/com/github/ryukato/link/developers/sdk/http/Utils.kt
+++ b/developers-sdk-kt/src/main/kotlin/com/github/ryukato/link/developers/sdk/http/Utils.kt
@@ -21,7 +21,7 @@ fun signature(
     @Suppress("UNCHECKED_CAST") val data = if (bodyTreeMap.isEmpty()) {
         "$nonce$timestamp$httpMethod$pathWithQueryParam"
     } else {
-        val concatenatedBody = bodyTreeMap.map { (k, v) ->
+        val concatenatedBody = bodyTreeMap.filterValues { it != null }.map { (k, v) ->
             when (v) {
                 is String -> "$k=$v"
                 is List<*> -> {


### PR DESCRIPTION
Signature was not calculated correctly.

Related: #28 